### PR TITLE
Add API Specification for question service

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "42crunch.vscode-openapi"
+    ]
+}

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -22,11 +22,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Question'
         '404':
-          description: A simple string response
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/ResourceNotFoundError'
+          description: A question with the specified ID was not found
     parameters:
       - name: "questionId"
         in: "path"
@@ -37,14 +33,6 @@ paths:
         example: 'a-hard-question'
 components:
   schemas:
-    ResourceNotFoundError:
-      type: object
-      properties:
-        code:
-          type: integer
-          format: int32
-        message:
-          type: string
     Question:
       type: object
       properties:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -26,4 +26,54 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/NotFoundErrorModel'
+                $ref: '#/components/schemas/ResourceNotFoundError'
+    parameters:
+      - name: "questionId"
+        in: "path"
+        description: "id of question to be found. This will be a kebab-case humar readable string"
+        required: true
+        schema:
+          type: string
+        example: 'a-hard-question'
+components:
+  schemas:
+    ResourceNotFoundError:
+      type: object
+      properties:
+        code:
+          type: integer
+          format: int32
+        message:
+          type: string
+    Question:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        body:
+          type: string
+        sampleAnswer:
+          type: string
+        successRate:
+          type: number
+          format: float
+        difficulty:
+          type: string
+          enum:
+            - easy
+            - medium
+            - hard
+        solved:
+          type: boolean
+        hints:
+          type: array
+          items:
+            type: string
+        parentTopicTitle:
+          type: string
+        questionAnswerOptions:
+          type: array
+          items:
+            type: string

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -198,7 +198,7 @@ paths:
               examples:
                 bad-request-body:
                   summary: Error response if one or more properties are illegal
-                  value: "Bad request: One or more parameters and their types are not present in a questopiction"
+                  value: "Bad request: One or more parameters and their types are not present in a topic"
                 update-error:
                   summary: Error response if one or more properties cannot be updated
                   value: "Bad request: One or more parameters could not be updated"
@@ -233,7 +233,7 @@ paths:
     post:
       summary: "creates a new topic"
       requestBody:
-        description: parameters of the question to be created
+        description: parameters of the topic to be created
         required: true
         content:
           application/json:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -82,6 +82,15 @@ paths:
                   value: "Bad request: One or more parameters could not be updated"
         '403':
           description: Forbidden
+    delete:
+      summary: "deletes a question with the matching id"
+      responses: 
+        '204':
+          description: the question was successfully deleted
+        '403':
+          description: Forbidden
+        '404':
+          description: A question with the specified ID was not found  
   /questions:
     post:
       summary: "creates a new question"
@@ -170,6 +179,35 @@ paths:
                   value: "Bad request: One or more parameters could not be updated"
         '403':
           description: Forbidden
+    delete:
+      summary: "deletes a topic with the matching id"
+      requestBody:
+        required: false
+        content: 
+          application/json:
+            schema:
+              type: object
+              properties:
+                delete_children:
+                  type: boolean
+                  default: false
+      responses: 
+        '204':
+          description: the topic was successfully deleted
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                parent-topic-deletion-attempt:
+                  summary: Error response for attempting to delete a topic that still has child questions 
+                  value: "Bad request: Attempted to delete a topic that still has child questions. Use the delete_children: true flag to remove these as well."
+        '403':
+          description: Forbidden
+        '404':
+          description: A topic with the specified ID was not found   
   /topics:
     post:
       summary: "creates a new topic"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -40,7 +40,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: '#/components/schemas/Pet'
+              $ref: '#/components/schemas/Question'
       responses: 
         '201':
           description: the created question

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -54,8 +54,6 @@ paths:
                     - easy
                     - medium
                     - hard
-                solved:
-                  type: boolean
                 hints:
                   type: array
                   items:
@@ -248,8 +246,6 @@ components:
             - easy
             - medium
             - hard
-        solved:
-          type: boolean
         hints:
           type: array
           items:
@@ -275,4 +271,3 @@ components:
             type: string
             description: questionId
             example: "a-kebab-case-question-id"
- 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -15,7 +15,7 @@ paths:
     parameters:
       - name: "questionId"
         in: "path"
-        description: "id of question to be found. This will be a kebab-case humar readable string"
+        description: "id of question to be found. This will be a kebab-case human readable string"
         required: true
         schema:
           type: string
@@ -113,6 +113,94 @@ paths:
                   value: "Bad request: Question with id and title already exists"
                 bad-request-body:
                   summary: Error response for incorrectly specifying the question to create 
+                  value: "Bad request: Bad parameters in request body"
+        '403':
+          description: Forbidden
+  /topics/{topicId}:
+    parameters:
+      - name: "topicId"
+        in: "path"
+        description: "id of topic to be found. This will be a kebab-case human readable string"
+        required: true
+        schema:
+          type: string
+        example: 'a-hard-topic'
+    get:
+      summary: "returns a topic with the matching id"
+      responses: 
+        '200':
+          description: the returned topic
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Topic'
+        '404':
+          description: A topic with the specified ID was not found
+    patch:
+      summary: "updates the topic with the specific id"
+      description: Updates the properties of an existing topic
+      requestBody:
+        required: true
+        content: 
+          application/json:
+            schema:
+              type: object
+              properties:
+                body:
+                  type: string
+                questions:
+                  type: array
+                  items:  
+                    type: string
+                    description: questionId
+                    example: "a-kebab-case-question-id"              
+      responses:
+        '204':
+          description: OK
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                bad-request-body:
+                  summary: Error response if one or more properties are illegal
+                  value: "Bad request: One or more parameters and their types are not present in a questopiction"
+                update-error:
+                  summary: Error response if one or more properties cannot be updated
+                  value: "Bad request: One or more parameters could not be updated"
+        '403':
+          description: Forbidden
+  /topics:
+    post:
+      summary: "creates a new topic"
+      requestBody:
+        description: parameters of the question to be created
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Topic'
+      responses: 
+        '201':
+          description: the created topic
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Topic'
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                duplicate-topic-creation-attempt:
+                  summary: Error response for attempting to duplicate a topic 
+                  value: "Bad request: Topic with id and title already exists"
+                bad-request-body:
+                  summary: Error response for incorrectly specifying the topic to create 
                   value: "Bad request: Bad parameters in request body"
         '403':
           description: Forbidden

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -1,0 +1,29 @@
+openapi: "3.0.0"
+info: 
+  title: "Question Service API"
+  description: "This is the API for the Question Service. It describes the models it employs and data it returns"
+  version: "1.0.0"
+servers:
+- url: https://question-service-develop.azurewebsites.net
+  description: Development server
+- url: https://question-service-master.azurewebsites.net
+  description: Staging server
+- url: https://question-service.azurewebsites.net
+  description: Production server
+paths:
+  /questions/{questionId}:
+    get:
+      summary: "returns a question with the matching id"
+      responses: 
+        '200':
+          description: the returned question
+          content: 
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Question'
+        '404':
+          description: A simple string response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NotFoundErrorModel'

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -265,6 +265,24 @@ paths:
                   value: "Bad request: Bad parameters in request body"
         '403':
           description: Forbidden
+    get:
+      parameters:
+        - in: query
+          name: title
+          schema:
+            type: string
+            default: ""
+          required: false
+      summary: "search for a topic by title"
+      responses: 
+        '200':
+          description: an array of the returned topics (or empty if none found)
+          content: 
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/Topic' 
   /topics/{topicId}/questions:
     parameters:
       - name: "topicId"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -133,9 +133,11 @@ paths:
         - in: query
           name: difficulty
           schema:
-            type: string
-            enum: [easy, medium, hard]
-          required: true
+            type: array
+            items: 
+              type: string
+              enum: [easy, medium, hard]
+          required: false
       summary: "search for a question by string and difficulty level"
       responses: 
         '200':

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -37,7 +37,7 @@ paths:
         required: true
         content: 
           application/json:
-        schema:
+            schema:
               type: object
               properties:
                 body:
@@ -58,7 +58,7 @@ paths:
                 hints:
                   type: array
                   items:
-          type: string
+                    type: string
                 parentTopicTitle:
                   type: string
                 questionAnswerOptions:
@@ -134,3 +134,19 @@ components:
           type: array
           items:
             type: string
+    Topic:
+      type: object
+      properties:
+        id:
+          type: string
+        title:
+          type: string
+        body:
+          type: string
+        questions:
+          type: array
+          items:  
+            type: string
+            description: questionId
+            example: "a-kebab-case-question-id"
+ 

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -32,6 +32,7 @@ paths:
         '404':
           description: A question with the specified ID was not found
     patch:
+      summary: "updates the question with the specific id"
       description: Updates the properties of an existing question
       requestBody:
         required: true
@@ -68,6 +69,21 @@ paths:
       responses:
         '204':
           description: OK
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                bad-request-body:
+                  summary: Error response if one or more properties are illegal
+                  value: "Bad request: One or more parameters and their types are not present in a question"
+                update-error:
+                  summary: Error response if one or more properties cannot be updated
+                  value: "Bad request: One or more parameters could not be updated"
+        '403':
+          description: Forbidden
   /questions:
     post:
       summary: "creates a new question"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -276,6 +276,20 @@ paths:
         example: 'a-hard-topic'
     get:
       summary: "returns full details for all questions contained in a topic"
+      parameters:
+        - in: query
+          name: title
+          schema:
+            type: string
+            default: ""
+          required: false
+        - in: query
+          name: difficulty
+          schema:
+            type: array
+            items: 
+              type: string
+              enum: [easy, medium, hard]
       responses: 
         '200':
           description: the returned questions

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -206,16 +206,12 @@ paths:
           description: Forbidden
     delete:
       summary: "deletes a topic with the matching id"
-      requestBody:
-        required: false
-        content: 
-          application/json:
-            schema:
-              type: object
-              properties:
-                delete_children:
-                  type: boolean
-                  default: false
+      parameters:
+        - in: query
+          required: false
+          name: delete_children
+          schema:
+            type: boolean
       responses: 
         '204':
           description: the topic was successfully deleted

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -204,6 +204,28 @@ paths:
                   value: "Bad request: Bad parameters in request body"
         '403':
           description: Forbidden
+  /topics/{topicId}/questions:
+    parameters:
+      - name: "topicId"
+        in: "path"
+        description: "id of topic to be found. This will be a kebab-case human readable string"
+        required: true
+        schema:
+          type: string
+        example: 'a-hard-topic'
+    get:
+      summary: "returns full details for all questions contained in a topic"
+      responses: 
+        '200':
+          description: the returned questions
+          content: 
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/Question'
+        '404':
+          description: A topic with the specified ID was not found
 components:
   schemas:
     Question:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -12,6 +12,14 @@ servers:
   description: Production server
 paths:
   /questions/{questionId}:
+    parameters:
+      - name: "questionId"
+        in: "path"
+        description: "id of question to be found. This will be a kebab-case humar readable string"
+        required: true
+        schema:
+          type: string
+        example: 'a-hard-question'
     get:
       summary: "returns a question with the matching id"
       responses: 
@@ -23,14 +31,43 @@ paths:
                 $ref: '#/components/schemas/Question'
         '404':
           description: A question with the specified ID was not found
-    parameters:
-      - name: "questionId"
-        in: "path"
-        description: "id of question to be found. This will be a kebab-case humar readable string"
+    patch:
+      description: Updates the properties of an existing question
+      requestBody:
         required: true
+        content: 
+          application/json:
         schema:
+              type: object
+              properties:
+                body:
+                  type: string
+                sampleAnswer:
+                  type: string
+                successRate:
+                  type: number
+                  format: float
+                difficulty:
+                  type: string
+                  enum:
+                    - easy
+                    - medium
+                    - hard
+                solved:
+                  type: boolean
+                hints:
+                  type: array
+                  items:
           type: string
-        example: 'a-hard-question'
+                parentTopicTitle:
+                  type: string
+                questionAnswerOptions:
+                  type: array
+                  items:
+                    type: string
+      responses:
+        '204':
+          description: OK
   /questions:
     post:
       summary: "creates a new question"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -123,6 +123,29 @@ paths:
                   value: "Bad request: Bad parameters in request body"
         '403':
           description: Forbidden
+    get:
+      parameters:
+        - in: query
+          name: title
+          schema:
+            type: string
+          required: true
+        - in: query
+          name: difficulty
+          schema:
+            type: string
+            enum: [easy, medium, hard]
+          required: true
+      summary: "search for a question by string and difficulty level"
+      responses: 
+        '200':
+          description: an array of the returned questions (or empty if none found)
+          content: 
+            application/json:
+              schema:
+                type: array
+                items: 
+                  $ref: '#/components/schemas/Question'         
   /topics/{topicId}:
     parameters:
       - name: "topicId"

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -31,6 +31,38 @@ paths:
         schema:
           type: string
         example: 'a-hard-question'
+  /questions:
+    post:
+      summary: "creates a new question"
+      requestBody:
+        description: parameters of the question to be created
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/Pet'
+      responses: 
+        '201':
+          description: the created question
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Question'
+        '400':
+          description: Bad request
+          content:
+            text/plain:
+              schema:
+                type: string
+              examples:
+                duplicate-question-creation-attempt:
+                  summary: Error response for attempting to duplicate a question 
+                  value: "Bad request: Question with id and title already exists"
+                bad-request-body:
+                  summary: Error response for incorrectly specifying the question to create 
+                  value: "Bad request: Bad parameters in request body"
+        '403':
+          description: Forbidden
 components:
   schemas:
     Question:


### PR DESCRIPTION
This can be viewed by going to the online [SWAGGER UI](https://petstore.swagger.io/?_ga=2.5743475.1188550758.1584748622-981401922.1584748622#/)  and pasting the link to the [openapi.yaml](https://raw.githubusercontent.com/math-dojo/question-service/ft7/openapi.yaml) in it. It should look like this:
![Captura de pantalla de 2020-03-21 03-32-26](https://user-images.githubusercontent.com/46621974/77218572-a0dc2c80-6b24-11ea-805d-348df863882f.png)
